### PR TITLE
Sample fixes

### DIFF
--- a/Microsoft.TeamServices.Samples.Client/ClientSampleHttpLogger.cs
+++ b/Microsoft.TeamServices.Samples.Client/ClientSampleHttpLogger.cs
@@ -75,17 +75,17 @@ namespace Microsoft.TeamServices.Samples.Client
                     DirectoryInfo baseOutputPath;
                     if (ClientSampleContext.CurrentContext.TryGetValue<DirectoryInfo>(PropertyOutputFilePath, out baseOutputPath))
                     {
-                        Dictionary<string, string> requestHeaders = new Dictionary<string, string>();
+                        Dictionary<string, IEnumerable<string>> requestHeaders = new Dictionary<string, IEnumerable<string>>();
                         foreach (var h in request.Headers.Where(kvp => { return !s_excludedHeaders.Contains(kvp.Key); }))
                         {
-                            requestHeaders[h.Key] = h.Value.First();
+                            requestHeaders[h.Key] = h.Value;
                         }
 
-                        Dictionary<string, string> responseHeaders = new Dictionary<string, string>();
+                        Dictionary<string, IEnumerable<string>> responseHeaders = new Dictionary<string, IEnumerable<string>>();
 
                         foreach (var h in response.Headers.Where(kvp => { return !s_excludedHeaders.Contains(kvp.Key); }))
                         {
-                            responseHeaders[h.Key] = h.Value.First();
+                            responseHeaders[h.Key] = h.Value;
                         }
 
                         dynamic requestBody = null;
@@ -206,7 +206,7 @@ namespace Microsoft.TeamServices.Samples.Client
         public String RequestUrl;
 
         [DataMember]
-        public Dictionary<String, String> RequestHeaders;
+        public Dictionary<String, IEnumerable<String>> RequestHeaders;
 
         [DataMember(EmitDefaultValue = false)]
         public Object RequestBody;
@@ -215,7 +215,7 @@ namespace Microsoft.TeamServices.Samples.Client
         public int StatusCode;
 
         [DataMember]
-        public Dictionary<String, String> ResponseHeaders;
+        public Dictionary<String, IEnumerable<String>> ResponseHeaders;
 
         [DataMember(EmitDefaultValue = false)]
         public Object ResponseBody;

--- a/Microsoft.TeamServices.Samples.Client/ClientSampleUtils.cs
+++ b/Microsoft.TeamServices.Samples.Client/ClientSampleUtils.cs
@@ -157,6 +157,8 @@ namespace Microsoft.TeamServices.Samples.Client
                         }
                         catch (Exception ex)
                         {
+                            //the innermost exception is the interesting one
+                            while (ex.InnerException != null) ex = ex.InnerException;
                             Console.WriteLine("FAILED! With exception: " + ex.Message);
                         }
                         finally

--- a/Microsoft.TeamServices.Samples.Client/Notification/SubscriptionsSample.cs
+++ b/Microsoft.TeamServices.Samples.Client/Notification/SubscriptionsSample.cs
@@ -358,13 +358,13 @@ namespace Microsoft.TeamServices.Samples.Client.Notification
             NotificationHttpClient notificationClient = connection.GetClient<NotificationHttpClient>();
             IEnumerable<NotificationSubscription> subscriptions = notificationClient.QuerySubscriptionsAsync(query).Result;
 
-            var subscriptionsByTeam = subscriptions.GroupBy<NotificationSubscription, Guid>(sub => { return Guid.Parse(sub.Subscriber.Id); });
+            var subscriptionsBySubscriber = subscriptions.GroupBy<NotificationSubscription, Guid>(sub => { return Guid.Parse(sub.Subscriber.Id); });
 
-            foreach (var group in subscriptionsByTeam)
+            foreach (var team in teams)
             {
                 // Find the corresponding team for this group
-                WebApiTeam team = teams.First(t => { return t.Id.Equals(group.Key); });
-
+                var group = subscriptionsBySubscriber.First(t => t.Key == team.Id);
+                
                 // Show the details for each subscription owned by this team 
                 foreach (NotificationSubscription subscription in group)
                 {

--- a/Microsoft.TeamServices.Samples.Client/WorkItemTracking/QueriesSample.cs
+++ b/Microsoft.TeamServices.Samples.Client/WorkItemTracking/QueriesSample.cs
@@ -15,7 +15,7 @@ namespace Microsoft.TeamServices.Samples.Client.WorkItemTracking
         public QueryHierarchyItem GetQueryByName()
         {
             string project = ClientSampleHelpers.FindAnyProject(this.Context).Name;
-            string queryName = "Shared Queries/Current Sprint";
+            string queryName = "Shared Queries/Feedback";
 
             VssConnection connection = Context.Connection;
             WorkItemTrackingHttpClient workItemTrackingClient = connection.GetClient<WorkItemTrackingHttpClient>();

--- a/Microsoft.TeamServices.Samples.Client/WorkItemTracking/WorkItemsSample.cs
+++ b/Microsoft.TeamServices.Samples.Client/WorkItemTracking/WorkItemsSample.cs
@@ -186,7 +186,7 @@ namespace Microsoft.TeamServices.Samples.Client.WorkItemTracking
             // Create the new work item
             WorkItem newWorkItem = workItemTrackingClient.CreateWorkItemAsync(patchDocument, project.Id, "Task").Result;
 
-            Console.WriteLine("Created work item ID {0} (1}", newWorkItem.Id, newWorkItem.Fields["System.Title"]);
+            Console.WriteLine("Created work item ID {0} {1}", newWorkItem.Id, newWorkItem.Fields["System.Title"]);
 
             // Save this newly created for later samples
             Context.SetValue<WorkItem>("$newWorkItem", newWorkItem);


### PR DESCRIPTION
This change makes some minor fixes to a couple of the samples, unpacks the exception in the case of an error in the sample runner, and changes the output to spit out all of the headers (in the case of multiple headers of the same type).