### PR TITLE
Update to M118 libraries; comment out broken parts of Graph samples

### DIFF
--- a/Microsoft.TeamServices.Samples.Client/ClientSampleHelpers.cs
+++ b/Microsoft.TeamServices.Samples.Client/ClientSampleHelpers.cs
@@ -119,6 +119,11 @@ namespace Microsoft.TeamServices.Samples.Client
             return context.Connection.AuthorizedIdentity.Id;
         }
 
+        public static string GetCurrentUserName(ClientSampleContext context)
+        {
+            return context.Connection.AuthorizedIdentity.ProviderDisplayName;
+        }
+
         public static String GetSampleTextFile()
         {
             return GetSampleFilePath("Microsoft.TeamServices.Samples.Client.WorkItemTracking.SampleFile.txt");

--- a/Microsoft.TeamServices.Samples.Client/ClientSampleHelpers.cs
+++ b/Microsoft.TeamServices.Samples.Client/ClientSampleHelpers.cs
@@ -119,7 +119,7 @@ namespace Microsoft.TeamServices.Samples.Client
             return context.Connection.AuthorizedIdentity.Id;
         }
 
-        public static string GetCurrentUserName(ClientSampleContext context)
+        public static string GetCurrentUserDisplayName(ClientSampleContext context)
         {
             return context.Connection.AuthorizedIdentity.ProviderDisplayName;
         }

--- a/Microsoft.TeamServices.Samples.Client/Graph/GroupsSample.cs
+++ b/Microsoft.TeamServices.Samples.Client/Graph/GroupsSample.cs
@@ -143,8 +143,8 @@ namespace Microsoft.TeamServices.Samples.Client.Graph
             ClientSampleHttpLogger.SetOperationName(this.Context, "MaterializeAADGroupByOIDWithVSID");
             GraphGroupCreationContext addAADGroupContext = new GraphGroupOriginIdCreationContext
             {
-                OriginId = "f0d20172-7b96-42f6-9436-941433654b48",
-                Id = Guid.NewGuid()
+                OriginId = "f0d20172-7b96-42f6-9436-941433654b48"
+                /* TODO: Id = Guid.NewGuid() */
             };
 
             GraphGroup newGroup = graphClient.CreateGroupAsync(addAADGroupContext).Result;

--- a/Microsoft.TeamServices.Samples.Client/Graph/MembershipSample.cs
+++ b/Microsoft.TeamServices.Samples.Client/Graph/MembershipSample.cs
@@ -64,7 +64,7 @@ namespace Microsoft.TeamServices.Samples.Client.Graph
             // Part 5: Check to see if the user is a member of the group
             // 
             ClientSampleHttpLogger.SetOperationName(this.Context, "CheckMembershipUser");
-            graphClient.CheckMembershipAsync(userDescriptor, groupDescriptor).SyncResult();
+            graphClient.CheckMembershipExistenceAsync(userDescriptor, groupDescriptor).SyncResult();
 
             //
             // Part 6: Get every group the subject(user) is a member of
@@ -84,7 +84,7 @@ namespace Microsoft.TeamServices.Samples.Client.Graph
             ClientSampleHttpLogger.SetOperationName(this.Context, "DeleteMembershipUser");
             graphClient.RemoveMembershipAsync(userDescriptor, groupDescriptor).SyncResult();
             try {
-                graphClient.CheckMembershipAsync(userDescriptor, groupDescriptor).SyncResult();
+                graphClient.CheckMembershipExistenceAsync(userDescriptor, groupDescriptor).SyncResult();
             }
             catch (Exception e) {
                 Context.Log("User is no longer a member of the group:" + e.Message);
@@ -100,12 +100,14 @@ namespace Microsoft.TeamServices.Samples.Client.Graph
             // Part 10: remove the user
 
             graphClient.DeleteUserAsync(userDescriptor).SyncResult();
+            
             //
             // Try to get the deleted user
             try
             {
                 newUser = graphClient.GetUserAsync(userDescriptor).Result;
-                if (!newUser.Disabled) throw new Exception();
+
+                // TODO: Disable no longer a field of GraphUser if (!newUser.Disabled) throw new Exception();
             }
             catch (Exception)
             {
@@ -165,7 +167,7 @@ namespace Microsoft.TeamServices.Samples.Client.Graph
             // Part 5: Check to see if the 'Contractors' group is a member of the 'Developers' group
             // 
             ClientSampleHttpLogger.SetOperationName(this.Context, "CheckMembershipVSTSGroup");
-            graphClient.CheckMembershipAsync(childGroupDescriptor, parentGroupDescriptor).SyncResult();
+            graphClient.CheckMembershipExistenceAsync(childGroupDescriptor, parentGroupDescriptor).SyncResult();
 
             //
             // Part 6: Get every group the subject('Contractors') is a member of
@@ -186,7 +188,7 @@ namespace Microsoft.TeamServices.Samples.Client.Graph
             graphClient.RemoveMembershipAsync(childGroupDescriptor, parentGroupDescriptor).SyncResult();
             try
             {
-                graphClient.CheckMembershipAsync(childGroupDescriptor, parentGroupDescriptor).SyncResult();
+                graphClient.CheckMembershipExistenceAsync(childGroupDescriptor, parentGroupDescriptor).SyncResult();
             }
             catch (Exception e)
             {
@@ -252,7 +254,7 @@ namespace Microsoft.TeamServices.Samples.Client.Graph
             // Part 5: Check to see if the AAD group is a member of the VSTS 'Developers' group
             // 
             ClientSampleHttpLogger.SetOperationName(this.Context, "CheckMembershipAADGroup");
-            graphClient.CheckMembershipAsync(aadGroupDescriptor, parentGroupDescriptor).SyncResult();
+            graphClient.CheckMembershipExistenceAsync(aadGroupDescriptor, parentGroupDescriptor).SyncResult();
 
             //
             // Part 6: Get every group the subject(AAD group) is a member of
@@ -273,7 +275,7 @@ namespace Microsoft.TeamServices.Samples.Client.Graph
             graphClient.RemoveMembershipAsync(aadGroupDescriptor, parentGroupDescriptor).SyncResult();
             try
             {
-                graphClient.CheckMembershipAsync(aadGroupDescriptor, parentGroupDescriptor).SyncResult();
+                graphClient.CheckMembershipExistenceAsync(aadGroupDescriptor, parentGroupDescriptor).SyncResult();
             }
             catch (Exception e)
             {

--- a/Microsoft.TeamServices.Samples.Client/Graph/UsersSample.cs
+++ b/Microsoft.TeamServices.Samples.Client/Graph/UsersSample.cs
@@ -73,7 +73,7 @@ namespace Microsoft.TeamServices.Samples.Client.Graph
             {
                 ClientSampleHttpLogger.SetOperationName(this.Context, "GetDisabledUserMSA");
                 newUser = graphClient.GetUserAsync(userDescriptor).Result;
-                if (!newUser.Disabled) throw new Exception();
+                // TODO: Fix if (!newUser.Disabled) throw new Exception();
             }
             catch (Exception)
             {
@@ -122,7 +122,7 @@ namespace Microsoft.TeamServices.Samples.Client.Graph
             {
                 ClientSampleHttpLogger.SetOperationName(this.Context, "GetDisabledUserAAD");
                 newUser = graphClient.GetUserAsync(userDescriptor).Result;
-                if (!newUser.Disabled) throw new Exception();
+                // TODO: if (!newUser.Disabled) throw new Exception();
             }
             catch (Exception)
             {
@@ -184,7 +184,7 @@ namespace Microsoft.TeamServices.Samples.Client.Graph
             try
             {
                 newUser = graphClient.GetUserAsync(userDescriptor).Result;
-                if (!newUser.Disabled) throw new Exception();
+                // TODO: if (!newUser.Disabled) throw new Exception();
             }
             catch (Exception)
             {
@@ -234,7 +234,7 @@ namespace Microsoft.TeamServices.Samples.Client.Graph
             try
             {
                 newUser = graphClient.GetUserAsync(userDescriptor).Result;
-                if (!newUser.Disabled) throw new Exception();
+                // TODO: if (!newUser.Disabled) throw new Exception();
             }
             catch (Exception)
             {
@@ -258,8 +258,8 @@ namespace Microsoft.TeamServices.Samples.Client.Graph
             ClientSampleHttpLogger.SetOperationName(this.Context, "MaterializeAADUserByOIDWithVSID");
             GraphUserCreationContext addAADUserContext = new GraphUserOriginIdCreationContext
             {
-                OriginId = "e97b0e7f-0a61-41ad-860c-748ec5fcb20b",
-                Id = Guid.NewGuid()
+                OriginId = "e97b0e7f-0a61-41ad-860c-748ec5fcb20b"
+                /* TODO: Id = Guid.NewGuid() */
             };
 
             GraphUser newUser = graphClient.CreateUserAsync(addAADUserContext).Result;
@@ -282,7 +282,7 @@ namespace Microsoft.TeamServices.Samples.Client.Graph
             try
             {
                 newUser = graphClient.GetUserAsync(userDescriptor).Result;
-                if (!newUser.Disabled) throw new Exception();
+                // TODO: if (!newUser.Disabled) throw new Exception();
             }
             catch (Exception)
             {

--- a/Microsoft.TeamServices.Samples.Client/Microsoft.TeamServices.Samples.Client.csproj
+++ b/Microsoft.TeamServices.Samples.Client/Microsoft.TeamServices.Samples.Client.csproj
@@ -48,68 +48,52 @@
       <HintPath>..\packages\WindowsAzure.ServiceBus.4.1.1\lib\net45\Microsoft.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Build2.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.116.0-preview\lib\net45\Microsoft.TeamFoundation.Build2.WebApi.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.Build2.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Chat.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.116.0-preview\lib\net45\Microsoft.TeamFoundation.Chat.WebApi.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.Chat.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Common, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Services.Client.15.116.0-preview\lib\net45\Microsoft.TeamFoundation.Common.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.VisualStudio.Services.Client.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.Common.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Core.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.116.0-preview\lib\net45\Microsoft.TeamFoundation.Core.WebApi.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.Core.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Dashboards.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.116.0-preview\lib\net45\Microsoft.TeamFoundation.Dashboards.WebApi.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.Dashboards.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.DistributedTask.Common.Contracts, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TeamFoundation.DistributedTask.Common.Contracts.15.116.0-preview\lib\net45\Microsoft.TeamFoundation.DistributedTask.Common.Contracts.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.TeamFoundation.DistributedTask.Common.Contracts.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.DistributedTask.Common.Contracts.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Policy.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.116.0-preview\lib\net45\Microsoft.TeamFoundation.Policy.WebApi.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.Policy.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.SourceControl.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.116.0-preview\lib\net45\Microsoft.TeamFoundation.SourceControl.WebApi.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.SourceControl.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Test.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.116.0-preview\lib\net45\Microsoft.TeamFoundation.Test.WebApi.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.Test.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.TestManagement.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.116.0-preview\lib\net45\Microsoft.TeamFoundation.TestManagement.WebApi.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.TestManagement.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Work.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.116.0-preview\lib\net45\Microsoft.TeamFoundation.Work.WebApi.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.Work.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.WorkItemTracking.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.116.0-preview\lib\net45\Microsoft.TeamFoundation.WorkItemTracking.WebApi.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.WorkItemTracking.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Services.Client.Interactive, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Services.InteractiveClient.15.116.0-preview\lib\net45\Microsoft.VisualStudio.Services.Client.Interactive.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.VisualStudio.Services.InteractiveClient.15.118.0-preview\lib\net45\Microsoft.VisualStudio.Services.Client.Interactive.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Services.Common, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Services.Client.15.116.0-preview\lib\net45\Microsoft.VisualStudio.Services.Common.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.VisualStudio.Services.Client.15.118.0-preview\lib\net45\Microsoft.VisualStudio.Services.Common.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Services.Notifications.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Services.Notifications.WebApi.15.116.0-preview\lib\net45\Microsoft.VisualStudio.Services.Notifications.WebApi.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.VisualStudio.Services.Notifications.WebApi.15.118.0-preview\lib\net45\Microsoft.VisualStudio.Services.Notifications.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Services.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Services.Client.15.116.0-preview\lib\net45\Microsoft.VisualStudio.Services.WebApi.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.VisualStudio.Services.Client.15.118.0-preview\lib\net45\Microsoft.VisualStudio.Services.WebApi.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Microsoft.TeamServices.Samples.Client/Microsoft.TeamServices.Samples.Client.csproj
+++ b/Microsoft.TeamServices.Samples.Client/Microsoft.TeamServices.Samples.Client.csproj
@@ -50,6 +50,10 @@
     <Reference Include="Microsoft.TeamFoundation.Build2.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.Build2.WebApi.dll</HintPath>
     </Reference>
+	<Reference Include="Microsoft.VisualStudio.Services.ReleaseManagement.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.Services.Release.Client.15.116.0-preview\lib\net45\Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.TeamFoundation.Chat.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.Chat.WebApi.dll</HintPath>
     </Reference>
@@ -136,6 +140,7 @@
     <Compile Include="Graph\GroupsSample.cs" />
     <Compile Include="Graph\UsersSample.cs" />
     <Compile Include="Notification\*.cs" />
+    <Compile Include="Release\ReleasesSample.cs" />
     <Compile Include="WorkItemTracking\AttachmentsSample.cs" />
     <Compile Include="WorkItemTracking\BatchSample.cs" />
     <Compile Include="WorkItemTracking\ClassificationNodesSample.cs" />

--- a/Microsoft.TeamServices.Samples.Client/Microsoft.TeamServices.Samples.Client.csproj
+++ b/Microsoft.TeamServices.Samples.Client/Microsoft.TeamServices.Samples.Client.csproj
@@ -51,7 +51,7 @@
       <HintPath>..\packages\Microsoft.TeamFoundationServer.Client.15.118.0-preview\lib\net45\Microsoft.TeamFoundation.Build2.WebApi.dll</HintPath>
     </Reference>
 	<Reference Include="Microsoft.VisualStudio.Services.ReleaseManagement.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.VisualStudio.Services.Release.Client.15.116.0-preview\lib\net45\Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.dll</HintPath>
+      <HintPath>..\packages\Microsoft.VisualStudio.Services.Release.Client.15.118.0-preview\lib\net45\Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Chat.WebApi, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Microsoft.TeamServices.Samples.Client/Release/ReleasesSample.cs
+++ b/Microsoft.TeamServices.Samples.Client/Release/ReleasesSample.cs
@@ -98,8 +98,7 @@ namespace Microsoft.TeamServices.Samples.Client.Release
                               DeployPhases = new List<DeployPhase>() {
                                                                        new AgentBasedDeployPhase()
                                                                            { Name = "Run on agent",
-                                                                             Rank = 1,
-                                                                             DeploymentInput =  new AgentDeploymentInput() {QueueId = 2}
+                                                                             Rank = 1
                                                                             }
                                                                       },
                               PreDeployApprovals = new ReleaseDefinitionApprovals() { Approvals = new List<ReleaseDefinitionApprovalStep>() { new ReleaseDefinitionApprovalStep() {IsAutomated = true, Rank = 1 } } },

--- a/Microsoft.TeamServices.Samples.Client/Release/ReleasesSample.cs
+++ b/Microsoft.TeamServices.Samples.Client/Release/ReleasesSample.cs
@@ -84,30 +84,58 @@ namespace Microsoft.TeamServices.Samples.Client.Release
         {
             string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
 
-            // Get a release client instance
-            VssConnection connection = Context.Connection;
-            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
-
             ReleaseDefinition definition = new ReleaseDefinition()
             {
                 Name = releaseDefinitionName,
                 Revision = 1,
                 Environments = new List<ReleaseDefinitionEnvironment>()
-                       { new ReleaseDefinitionEnvironment()
-                            { Name = "PROD",
-                              DeployPhases = new List<DeployPhase>() {
-                                                                       new AgentBasedDeployPhase()
-                                                                           { Name = "Run on agent",
-                                                                             Rank = 1
-                                                                            }
-                                                                      },
-                              PreDeployApprovals = new ReleaseDefinitionApprovals() { Approvals = new List<ReleaseDefinitionApprovalStep>() { new ReleaseDefinitionApprovalStep() {IsAutomated = true, Rank = 1 } } },
-                              PostDeployApprovals = new ReleaseDefinitionApprovals() { Approvals = new List<ReleaseDefinitionApprovalStep>() {new ReleaseDefinitionApprovalStep() {IsAutomated = true, Rank = 1 } } },
-                              RetentionPolicy = new EnvironmentRetentionPolicy() { DaysToKeep = 30, ReleasesToKeep = 3, RetainBuild = true}
-                             }
-                         }
-
+                {
+                    new ReleaseDefinitionEnvironment()
+                    {
+                        Name = "PROD",
+                        DeployPhases = new List<DeployPhase>()
+                            {
+                                new AgentBasedDeployPhase()
+                                {
+                                    Name = "Run on agent",
+                                    Rank = 1
+                                }
+                            },
+                        PreDeployApprovals = new ReleaseDefinitionApprovals()
+                        {
+                            Approvals = new List<ReleaseDefinitionApprovalStep>()
+                            {
+                                new ReleaseDefinitionApprovalStep()
+                                {
+                                    IsAutomated = true,
+                                    Rank = 1
+                                }
+                            }
+                        },
+                        PostDeployApprovals = new ReleaseDefinitionApprovals()
+                        {
+                            Approvals = new List<ReleaseDefinitionApprovalStep>()
+                            {
+                                new ReleaseDefinitionApprovalStep()
+                                {
+                                    IsAutomated = true,
+                                    Rank = 1
+                                }
+                            }
+                        },
+                        RetentionPolicy = new EnvironmentRetentionPolicy()
+                        {
+                            DaysToKeep = 30,
+                            ReleasesToKeep = 3,
+                            RetainBuild = true
+                        }
+                    }
+                }
             };
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
 
             // create a release definition
             ReleaseDefinition releaseDefinition = releaseClient.CreateReleaseDefinitionAsync(project: projectName, releaseDefinition: definition).Result;
@@ -333,7 +361,7 @@ namespace Microsoft.TeamServices.Samples.Client.Release
                     continuationToken = parsedContinuationToken;
                 }
             } while ((continuationToken != 0) && parseResult);
-     
+
             // Show the approvals
             foreach (ReleaseApproval releaseApproval in releaseApprovals)
             {
@@ -384,7 +412,7 @@ namespace Microsoft.TeamServices.Samples.Client.Release
         public IEnumerable<ReleaseApproval> ListPendingApprovalsForASpecificARelease()
         {
             string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
-            
+
             // Get a release client instance
             VssConnection connection = Context.Connection;
             ReleaseHttpClient2 releaseClient = connection.GetClient<ReleaseHttpClient2>();
@@ -445,7 +473,7 @@ namespace Microsoft.TeamServices.Samples.Client.Release
         }
 
         [ClientSampleMethod]
-        public void DeleteAReleaseDefinition()
+        public void DeleteReleaseDefinition()
         {
             string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
 

--- a/Microsoft.TeamServices.Samples.Client/Release/ReleasesSample.cs
+++ b/Microsoft.TeamServices.Samples.Client/Release/ReleasesSample.cs
@@ -1,0 +1,512 @@
+﻿using Microsoft.VisualStudio.Services.ReleaseManagement.WebApi;
+using Microsoft.VisualStudio.Services.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Clients;
+using Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Contracts;
+using Newtonsoft.Json;
+
+namespace Microsoft.TeamServices.Samples.Client.Release
+{
+    [ClientSample(ReleaseManagementApiConstants.ReleaseAreaName, ReleaseManagementApiConstants.ReleasesResource)]
+    public class ReleasesSample : ClientSample
+    {
+        private const string releaseDefinitionName = "Fabrikam-web";
+
+        [ClientSampleMethod]
+
+        public List<ReleaseDefinition> ListAllReleaseDefinitions()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
+
+            // Show the releaes definitions
+            List<ReleaseDefinition> releaseDefinitions = releaseClient.GetReleaseDefinitionsAsync(project: projectName).Result;
+
+            foreach (ReleaseDefinition releaseDefinition in releaseDefinitions)
+            {
+                Console.WriteLine("{0} {1}", releaseDefinition.Id.ToString().PadLeft(6), releaseDefinition.Name);
+            }
+
+            return releaseDefinitions;
+        }
+
+        [ClientSampleMethod]
+
+        public List<ReleaseDefinition> ListAllReleaseDefinitionsWithEnvironmentsExpanded()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
+
+            // Show the releaes definitions
+            List<ReleaseDefinition> releaseDefinitions = releaseClient.GetReleaseDefinitionsAsync(project: projectName, expand: ReleaseDefinitionExpands.Environments).Result;
+
+            foreach (ReleaseDefinition releaseDefinition in releaseDefinitions)
+            {
+                Console.WriteLine("{0} {1}", releaseDefinition.Id.ToString().PadLeft(6), releaseDefinition.Name);
+            }
+
+            return releaseDefinitions;
+        }
+
+        [ClientSampleMethod]
+
+        public List<ReleaseDefinition> ListAllReleaseDefinitionsWithArtifactsExpanded()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
+
+            // Show the releaes definitions
+            List<ReleaseDefinition> releaseDefinitions = releaseClient.GetReleaseDefinitionsAsync(project: projectName, expand: ReleaseDefinitionExpands.Artifacts).Result;
+
+            foreach (ReleaseDefinition releaseDefinition in releaseDefinitions)
+            {
+                Console.WriteLine("{0} {1}", releaseDefinition.Id.ToString().PadLeft(6), releaseDefinition.Name);
+            }
+
+            return releaseDefinitions;
+        }
+
+        [ClientSampleMethod]
+
+        public ReleaseDefinition GetAReleaseDefinition()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
+
+            List<ReleaseDefinition> releaseDefinitions = releaseClient.GetReleaseDefinitionsAsync(project: projectName).Result;
+
+            int releaseDefinitionId = releaseDefinitions.FirstOrDefault().Id;
+
+            // Show a releaes definitions
+            ReleaseDefinition releaseDefinition = releaseClient.GetReleaseDefinitionAsync(project: projectName, definitionId: releaseDefinitionId).Result;
+
+            Console.WriteLine("{0} {1}", releaseDefinition.Id.ToString().PadLeft(6), releaseDefinition.Name);
+
+            return releaseDefinition;
+        }
+
+        [ClientSampleMethod]
+
+        public ReleaseDefinition CreateAReleaseDefinition()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
+
+            // JSON to create release definition
+            string releaseDefinitionJson = "{\"name\":\"Fabrikam-web\",\"revision\" : 1,\"environments\":[{\"name\":\"PROD\",\"deployPhases\":[{\"name\":\"Run on agent\",\"phaseType\":1,\"rank\":1, \"deploymentInput\":{\"queueId\":2}}],\"preDeployApprovals\":{\"approvals\":[{\"rank\":1,\"isAutomated\":true}]},\"postDeployApprovals\":{\"approvals\":[{\"rank\":1,\"isAutomated\":true}]},\"retentionPolicy\":{\"daysToKeep\":30,\"releasesToKeep\":3,\"retainBuild\":true}}]}";
+
+            ReleaseDefinition definition = JsonConvert.DeserializeObject<ReleaseDefinition>(releaseDefinitionJson);
+
+            // create a release definition
+            ReleaseDefinition releaseDefinition = releaseClient.CreateReleaseDefinitionAsync(project: projectName, releaseDefinition: definition).Result;
+
+            Console.WriteLine("{0} {1}", releaseDefinition.Id.ToString().PadLeft(6), releaseDefinition.Name);
+
+            return releaseDefinition;
+        }
+
+        [ClientSampleMethod]
+
+        public ReleaseDefinition UpdateAReleaseDefinition()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
+
+            List<ReleaseDefinition> releaseDefinitions = releaseClient.GetReleaseDefinitionsAsync(project: projectName, searchText: releaseDefinitionName).Result;
+            int releaseDefinitionId = releaseDefinitions.FirstOrDefault().Id;
+            ReleaseDefinition releaseDefinition = releaseClient.GetReleaseDefinitionAsync(project: projectName, definitionId: releaseDefinitionId).Result;
+
+            // add a non secret variable to definition
+            ConfigurationVariableValue variable = new ConfigurationVariableValue();
+            variable.Value = "NonSecretValue";
+            variable.IsSecret = false;
+            releaseDefinition.Variables.Add("NonSecretVariable", variable);
+
+            // update release definition
+            ReleaseDefinition updatedReleaseDefinition = releaseClient.UpdateReleaseDefinitionAsync(project: projectName, releaseDefinition: releaseDefinition).Result;
+
+            Console.WriteLine("{0} {1}", updatedReleaseDefinition.Id.ToString().PadLeft(6), updatedReleaseDefinition.Name);
+
+            return releaseDefinition;
+        }
+
+        [ClientSampleMethod]
+
+        public IEnumerable<ReleaseDefinitionRevision> GetReleaseDefinitionRevisions()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
+
+            List<ReleaseDefinition> releaseDefinitions = releaseClient.GetReleaseDefinitionsAsync(project: projectName, searchText: releaseDefinitionName).Result;
+            int releaseDefinitionId = releaseDefinitions.FirstOrDefault().Id;
+
+            // Get revision
+            List<ReleaseDefinitionRevision> revisions = releaseClient.GetReleaseDefinitionHistoryAsync(projectName, releaseDefinitionId).Result;
+
+            foreach (ReleaseDefinitionRevision revision in revisions)
+            {
+                Console.WriteLine("{0} {1}", revision.DefinitionId.ToString().PadLeft(6), revision.Revision);
+            }
+
+            return revisions;
+        }
+
+        [ClientSampleMethod]
+
+        public System.IO.Stream GetReleaseDefinitionForARevision()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
+
+            List<ReleaseDefinition> releaseDefinitions = releaseClient.GetReleaseDefinitionsAsync(project: projectName, searchText: releaseDefinitionName).Result;
+            int releaseDefinitionId = releaseDefinitions.FirstOrDefault().Id;
+
+            // Get revision
+            System.IO.Stream revision = releaseClient.GetReleaseDefinitionRevisionAsync(projectName, releaseDefinitionId, revision: 1).Result;
+
+            return revision;
+        }
+
+        [ClientSampleMethod]
+
+        public void DeleteAReleaseDefinition()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
+
+            List<ReleaseDefinition> releaseDefinitions = releaseClient.GetReleaseDefinitionsAsync(project: projectName, searchText: releaseDefinitionName).Result;
+            int releaseDefinitionId = releaseDefinitions.FirstOrDefault().Id;
+
+            // delete release definition
+            releaseClient.DeleteReleaseDefinitionAsync(project: projectName, definitionId: releaseDefinitionId).SyncResult();
+
+        }
+
+        [ClientSampleMethod]
+
+        public IEnumerable<Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release> ListAllReleases()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient2 releaseClient = connection.GetClient<ReleaseHttpClient2>();
+
+            List<Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release> releases = releaseClient.GetReleasesAsync(project: projectName).Result;
+
+            // Show the releases
+            foreach (Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release release in releases)
+            {
+                Console.WriteLine("{0} {1}", release.Id.ToString().PadLeft(6), release.Status);
+            }
+
+            return releases;
+        }
+
+        [ClientSampleMethod]
+
+        public IEnumerable<Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release> ListAllReleasesForAReleaseDefinition()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient2 releaseClient = connection.GetClient<ReleaseHttpClient2>();
+            List<ReleaseDefinition> releaseDefinitions = releaseClient.GetReleaseDefinitionsAsync(project: projectName).Result;
+            int releaseDefinitionId = releaseDefinitions.FirstOrDefault().Id;
+            List<Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release> releases = releaseClient.GetReleasesAsync(project: projectName, definitionId: releaseDefinitionId).Result;
+
+            // Show the approvals
+            foreach (Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release release in releases)
+            {
+                Console.WriteLine("{0} {1}", release.Id.ToString().PadLeft(6), release.Status);
+            }
+
+            return releases;
+        }
+
+        [ClientSampleMethod]
+
+        public Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release GetARelease()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
+
+            List<Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release> releases = releaseClient.GetReleasesAsync(project: projectName).Result;
+
+            int releaseId = releases.FirstOrDefault().Id;
+
+            // Show a releaes
+            Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release release = releaseClient.GetReleaseAsync(project: projectName, releaseId: releaseId).Result;
+
+            Console.WriteLine("{0} {1}", release.Id.ToString().PadLeft(6), release.Name);
+
+            return release;
+        }
+
+        [ClientSampleMethod]
+
+        public Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release CreateARelease()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
+
+            List<ReleaseDefinition> releaseDefinitions = releaseClient.GetReleaseDefinitionsAsync(project: projectName).Result;
+            int releaseDefinitionId = releaseDefinitions.FirstOrDefault().Id;
+
+            Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release release = CreateRelease(releaseClient, releaseDefinitionId, projectName);
+
+            Console.WriteLine("{0} {1}", release.Id.ToString().PadLeft(6), release.Name);
+
+            return release;
+        }
+
+        [ClientSampleMethod]
+
+        public Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release UpdateReleaseEnvironment()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
+
+            List<ReleaseDefinition> releaseDefinitions = releaseClient.GetReleaseDefinitionsAsync(project: projectName).Result;
+            int releaseDefinitionId = releaseDefinitions.FirstOrDefault().Id;
+            Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release release = CreateRelease(releaseClient, releaseDefinitionId, projectName);
+
+            ReleaseEnvironmentUpdateMetadata releaseEnvironmentUpdateMetadata = new ReleaseEnvironmentUpdateMetadata()
+            {
+                Status = EnvironmentStatus.InProgress
+            };
+
+            int releaseEnvironmentId = release.Environments.FirstOrDefault().Id;
+
+            // Abandon a release
+            ReleaseEnvironment releaseEnvironment = releaseClient.UpdateReleaseEnvironmentAsync(releaseEnvironmentUpdateMetadata, projectName, release.Id, releaseEnvironmentId).Result;
+            Console.WriteLine("{0} {1}", releaseEnvironment.Id.ToString().PadLeft(6), releaseEnvironment.Name);
+
+            return release;
+        }
+
+        [ClientSampleMethod]
+
+        public Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release AbandonAnActiveRelease()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
+
+            List<ReleaseDefinition> releaseDefinitions = releaseClient.GetReleaseDefinitionsAsync(project: projectName).Result;
+            int releaseDefinitionId = releaseDefinitions.FirstOrDefault().Id;
+            Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release release = CreateRelease(releaseClient, releaseDefinitionId, projectName);
+
+            ReleaseUpdateMetadata releaseUpdateMetadata = new ReleaseUpdateMetadata()
+            {
+                Comment = "Abandon the release",
+                Status = ReleaseStatus.Abandoned
+            };
+
+            // Abandon a release
+            Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release updatedRelease = releaseClient.UpdateReleaseResourceAsync(releaseUpdateMetadata, projectName, release.Id).Result;
+            Console.WriteLine("{0} {1}", updatedRelease.Id.ToString().PadLeft(6), updatedRelease.Name);
+
+            return release;
+        }
+
+        [ClientSampleMethod]
+
+        public IEnumerable<ReleaseApproval> ListAllPendingApprovals()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient2 releaseClient = connection.GetClient<ReleaseHttpClient2>();
+
+            List<ReleaseApproval> releaseApprovals = new List<ReleaseApproval>();
+
+            // Iterate (as needed) to get the full set of approvals
+            int continuationToken = 0;
+            bool parseResult;
+            do
+            {
+                IPagedCollection<ReleaseApproval> releaseApprovalsPage = releaseClient.GetApprovalsAsync2(project: projectName, continuationToken: continuationToken).Result;
+
+                releaseApprovals.AddRange(releaseApprovalsPage);
+
+                int parsedContinuationToken = 0;
+                parseResult = int.TryParse(releaseApprovalsPage.ContinuationToken, out parsedContinuationToken);
+                if (parseResult)
+                {
+                    continuationToken = parsedContinuationToken;
+                }
+            } while ((continuationToken != 0) && parseResult);
+     
+            // Show the approvals
+            foreach (ReleaseApproval releaseApproval in releaseApprovals)
+            {
+                Console.WriteLine("{0} {1}", releaseApproval.Id.ToString().PadLeft(6), releaseApproval.Status);
+            }
+
+            return releaseApprovals;
+        }
+
+        [ClientSampleMethod]
+
+        public IEnumerable<ReleaseApproval> ListPendingApprovalsForASpecificUser()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+            string assignedToFilter = ClientSampleHelpers.GetCurrentUserName(this.Context);
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient2 releaseClient = connection.GetClient<ReleaseHttpClient2>();
+
+            List<ReleaseApproval> releaseApprovals = new List<ReleaseApproval>();
+
+            // Iterate (as needed) to get the full set of approvals
+            int continuationToken = 0;
+            bool parseResult;
+            do
+            {
+                IPagedCollection<ReleaseApproval> releaseApprovalsPage = releaseClient.GetApprovalsAsync2(project: projectName, assignedToFilter: assignedToFilter, continuationToken: continuationToken).Result;
+
+                releaseApprovals.AddRange(releaseApprovalsPage);
+
+                int parsedContinuationToken = 0;
+                parseResult = int.TryParse(releaseApprovalsPage.ContinuationToken, out parsedContinuationToken);
+                if (parseResult)
+                {
+                    continuationToken = parsedContinuationToken;
+                }
+            } while ((continuationToken != 0) && parseResult);
+
+            // Show the approvals
+            foreach (ReleaseApproval releaseApproval in releaseApprovals)
+            {
+                Console.WriteLine("{0} {1}", releaseApproval.Id.ToString().PadLeft(6), releaseApproval.Status);
+            }
+
+            return releaseApprovals;
+        }
+
+        [ClientSampleMethod]
+
+        public IEnumerable<ReleaseApproval> ListPendingApprovalsForASpecificARelease()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+            
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient2 releaseClient = connection.GetClient<ReleaseHttpClient2>();
+
+            var releases = releaseClient.GetReleasesAsync(project: projectName).Result;
+
+            int releaseIdFilter = releases.FirstOrDefault().Id;
+
+            List<ReleaseApproval> releaseApprovals = new List<ReleaseApproval>();
+
+            // Iterate (as needed) to get the full set of approvals
+            int continuationToken = 0;
+            bool parseResult;
+            do
+            {
+                IPagedCollection<ReleaseApproval> releaseApprovalsPage = releaseClient.GetApprovalsAsync2(project: projectName, releaseIdsFilter: new List<int> { releaseIdFilter }, continuationToken: continuationToken).Result;
+
+                releaseApprovals.AddRange(releaseApprovalsPage);
+
+                int parsedContinuationToken = 0;
+                parseResult = int.TryParse(releaseApprovalsPage.ContinuationToken, out parsedContinuationToken);
+                if (parseResult)
+                {
+                    continuationToken = parsedContinuationToken;
+                }
+            } while ((continuationToken != 0) && parseResult);
+
+            // Show the approvals
+            foreach (ReleaseApproval releaseApproval in releaseApprovals)
+            {
+                Console.WriteLine("{0} {1}", releaseApproval.Id.ToString().PadLeft(6), releaseApproval.Status);
+            }
+
+            return releaseApprovals;
+        }
+
+        [ClientSampleMethod]
+
+        public void UpdateStatusOfAnApprovalFromPendingToApproved()
+        {
+            string projectName = ClientSampleHelpers.FindAnyProject(this.Context).Name;
+            string assignedToFilter = ClientSampleHelpers.GetCurrentUserName(this.Context);
+
+            // Get a release client instance
+            VssConnection connection = Context.Connection;
+            ReleaseHttpClient releaseClient = connection.GetClient<ReleaseHttpClient>();
+            ReleaseApproval updateApproval = new ReleaseApproval { Status = ApprovalStatus.Approved, Comments = "Good to go!" };
+
+            // Get all pending approval to the current user
+            IList<ReleaseApproval> releaseApprovalsPage = releaseClient.GetApprovalsAsync(project: projectName, assignedToFilter: assignedToFilter).Result;
+            ReleaseApproval releaseApprovalToApprove = releaseApprovalsPage.FirstOrDefault();
+
+            if (releaseApprovalToApprove != null)
+            {
+                ReleaseApproval approval = releaseClient.UpdateReleaseApprovalAsync(project: projectName, approval: updateApproval, approvalId: releaseApprovalToApprove.Id).Result;
+
+                Console.WriteLine("{0} {1}", approval.Id.ToString().PadLeft(6), approval.Status);
+            }
+        }
+
+        private static VisualStudio.Services.ReleaseManagement.WebApi.Release CreateRelease(ReleaseHttpClient releaseClient, int releaseDefinitionId, string projectName)
+        {
+            BuildVersion instanceReference = new BuildVersion { Id = "2" };
+            ArtifactMetadata artifact = new ArtifactMetadata { Alias = "Fabrikam.CI", InstanceReference = instanceReference };
+            ReleaseStartMetadata releaseStartMetaData = new ReleaseStartMetadata();
+            releaseStartMetaData.DefinitionId = releaseDefinitionId;
+            releaseStartMetaData.Description = "Creating Sample release";
+            releaseStartMetaData.Artifacts = new[] { artifact };
+            // Create  a releaes
+            Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Release release =
+                releaseClient.CreateReleaseAsync(project: projectName, releaseStartMetadata: releaseStartMetaData).Result;
+            return release;
+        }
+    }
+}

--- a/Microsoft.TeamServices.Samples.Client/packages.config
+++ b/Microsoft.TeamServices.Samples.Client/packages.config
@@ -4,12 +4,12 @@
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.9" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Logging" version="1.1.3" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Tokens" version="5.1.3" targetFramework="net452" />
-  <package id="Microsoft.TeamFoundation.DistributedTask.Common.Contracts" version="15.116.0-preview" targetFramework="net452" />
-  <package id="Microsoft.TeamFoundationServer.Client" version="15.116.0-preview" targetFramework="net452" />
+  <package id="Microsoft.TeamFoundation.DistributedTask.Common.Contracts" version="15.118.0-preview" targetFramework="net452" />
+  <package id="Microsoft.TeamFoundationServer.Client" version="15.118.0-preview" targetFramework="net452" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net452" />
-  <package id="Microsoft.VisualStudio.Services.Client" version="15.116.0-preview" targetFramework="net452" />
-  <package id="Microsoft.VisualStudio.Services.InteractiveClient" version="15.116.0-preview" targetFramework="net452" />
-  <package id="Microsoft.VisualStudio.Services.Notifications.WebApi" version="15.116.0-preview" targetFramework="net452" />
+  <package id="Microsoft.VisualStudio.Services.Client" version="15.118.0-preview" targetFramework="net452" />
+  <package id="Microsoft.VisualStudio.Services.InteractiveClient" version="15.118.0-preview" targetFramework="net452" />
+  <package id="Microsoft.VisualStudio.Services.Notifications.WebApi" version="15.118.0-preview" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.1.3" targetFramework="net452" />
   <package id="WindowsAzure.ServiceBus" version="4.1.1" targetFramework="net452" />

--- a/Microsoft.TeamServices.Samples.Client/packages.config
+++ b/Microsoft.TeamServices.Samples.Client/packages.config
@@ -10,6 +10,7 @@
   <package id="Microsoft.VisualStudio.Services.Client" version="15.118.0-preview" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Services.InteractiveClient" version="15.118.0-preview" targetFramework="net452" />
   <package id="Microsoft.VisualStudio.Services.Notifications.WebApi" version="15.118.0-preview" targetFramework="net452" />
+  <package id="Microsoft.VisualStudio.Services.Release.Client" version="15.118.0-preview" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
   <package id="System.IdentityModel.Tokens.Jwt" version="5.1.3" targetFramework="net452" />
   <package id="WindowsAzure.ServiceBus" version="4.1.1" targetFramework="net452" />


### PR DESCRIPTION
Moving to latest library (M118).

@justmarks - I had to comment out a few lines in the Graph samples that had compilation errors after moving to the latest library. I will open an issue so you can go back and fix these --- I don't want to block the update on this.