### PR TITLE
Added sample for token administration

### DIFF
--- a/ClientLibrary/Snippets/Microsoft.TeamServices.Samples.Client/Microsoft.TeamServices.Samples.Client.csproj
+++ b/ClientLibrary/Snippets/Microsoft.TeamServices.Samples.Client/Microsoft.TeamServices.Samples.Client.csproj
@@ -154,13 +154,14 @@
     <Compile Include="Graph\MembershipStatesSample.cs" />
     <Compile Include="Graph\StorageKeySample.cs" />
     <Compile Include="Graph\SubjectLookupSample.cs" />
+    <Compile Include="Graph\GroupsSample.cs" />
+    <Compile Include="Graph\UsersSample.cs" />
+    <Compile Include="Graph\MembershipSample.cs" />
     <Compile Include="ProjectsAndTeams\ProcessesSample.cs" />
     <Compile Include="ProjectsAndTeams\ProjectCollectionsSample.cs" />
     <Compile Include="ProjectsAndTeams\ProjectsSample.cs" />
     <Compile Include="ProjectsAndTeams\TeamsSample.cs" />
     <Compile Include="Git\*.cs" />
-    <Compile Include="Graph\GroupsSample.cs" />
-    <Compile Include="Graph\UsersSample.cs" />
     <Compile Include="Notification\*.cs" />
     <Compile Include="Release\ReleasesSample.cs" />
     <Compile Include="Security\AccessControlListsSample.cs" />
@@ -171,6 +172,9 @@
     <Compile Include="Tfvc\ChangesetChangesSample.cs" />
     <Compile Include="Tfvc\BranchesSample.cs" />
     <Compile Include="Tfvc\ChangesetsSample.cs" />
+    <Compile Include="TokenAdmin\FromFutureWebApi\TokenAdminContracts.cs" />
+    <Compile Include="TokenAdmin\FromFutureWebApi\TokenAdminHttpClient.cs" />
+    <Compile Include="TokenAdmin\TokenAdminSample.cs" />
     <Compile Include="WorkItemTracking\AttachmentsSample.cs" />
     <Compile Include="WorkItemTracking\BatchSample.cs" />
     <Compile Include="WorkItemTracking\ClassificationNodesSample.cs" />
@@ -190,7 +194,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <Compile Include="Graph\MembershipSample.cs" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>

--- a/ClientLibrary/Snippets/Microsoft.TeamServices.Samples.Client/TokenAdmin/FromFutureWebApi/TokenAdminContracts.cs
+++ b/ClientLibrary/Snippets/Microsoft.TeamServices.Samples.Client/TokenAdmin/FromFutureWebApi/TokenAdminContracts.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.Services.DelegatedAuthorization;
+
+namespace Microsoft.VisualStudio.Services.TokenAdmin.Client
+{
+    public static class TokenAdminResourceIds
+    {
+        public const string AreaName = "TokenAdmin";
+        public const string AreaId = "af68438b-ed04-4407-9eb6-f1dbae3f922e";
+
+        public const string PersonalAccessTokensResource = "PersonalAccessTokens";
+        public static readonly Guid PersonalAccessTokensLocationId = new Guid("{af68438b-ed04-4407-9eb6-f1dbae3f922e}");
+
+        public const string RevocationsResource = "Revocations";
+        public static readonly Guid RevocationsLocationId = new Guid("{a9c08b2c-5466-4e22-8626-1ff304ffdf0f}");
+
+        public const string RevocationRulesResource = "RevocationRules";
+        public static readonly Guid RevocationRulesLocationId = new Guid("{ee4afb16-e7ab-4ed8-9d4b-4ef3e78f97e4}");
+    }
+
+    /// <summary>
+    /// A paginatated list of session tokens.
+    /// Session tokens correspond to OAuth credentials such as personal access tokens (PATs)
+    /// and other OAuth authorizations.
+    /// </summary>
+    [DataContract]
+    public class TokenAdminPagedSessionTokens
+    {
+        /// <summary>
+        /// The list of all session tokens in the current page.
+        /// </summary>
+        [DataMember(Name = "Value")]
+        public IEnumerable<SessionToken> SessionTokens { get; set; }
+
+        /// <summary>
+        /// The continuation token that can be used to retrieve the next page of session tokens,
+        /// or <code>null</code> if there is no next page.
+        /// </summary>
+        [DataMember]
+        public Guid? ContinuationToken { get; set; }
+    }
+    
+    /// <summary>
+    /// A rule which is applied to disable any incoming delegated authorization
+    /// which matches the given properties.
+    /// </summary>
+    public class TokenAdminRevocationRule
+    {
+        /// <summary>
+        /// The OAuth scope for which matching authorizations should be rejected.
+        /// For a list of all OAuth scopes supported by VSTS, see:
+        /// https://docs.microsoft.com/en-us/vsts/integrate/get-started/authentication/oauth?view=vsts#scopes
+        /// </summary>
+        public string Scope { get; set; }
+    }
+
+    /// <summary>
+    /// A request to revoke a particular delegated authorization.
+    /// </summary>
+    public class TokenAdminRevocation
+    {
+        /// <summary>
+        /// The authorization ID of the OAuth authorization to revoke.
+        /// </summary>
+        public Guid AuthorizationId { get; set; }
+    }
+}

--- a/ClientLibrary/Snippets/Microsoft.TeamServices.Samples.Client/TokenAdmin/FromFutureWebApi/TokenAdminHttpClient.cs
+++ b/ClientLibrary/Snippets/Microsoft.TeamServices.Samples.Client/TokenAdmin/FromFutureWebApi/TokenAdminHttpClient.cs
@@ -1,0 +1,154 @@
+﻿/*
+ * ---------------------------------------------------------
+ * Copyright(C) Microsoft Corporation. All rights reserved.
+ * ---------------------------------------------------------
+ *
+ * ---------------------------------------------------------
+ * Generated file, DO NOT EDIT
+ * ---------------------------------------------------------
+ *
+ * See following wiki page for instructions on how to regenerate:
+ *   https://vsowiki.com/index.php?title=Rest_Client_Generation
+ *
+ * Configuration file:
+ *   vssf\client\webapi\httpclients\clientgeneratorconfigs\tokenadmin.genclient.json
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Formatting;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.WebApi;
+
+namespace Microsoft.VisualStudio.Services.TokenAdmin.Client
+{
+    [ResourceArea(TokenAdminResourceIds.AreaId)]
+    public class TokenAdminHttpClient : VssHttpClientBase
+    {
+        public TokenAdminHttpClient(Uri baseUrl, VssCredentials credentials)
+            : base(baseUrl, credentials)
+        {
+        }
+
+        public TokenAdminHttpClient(Uri baseUrl, VssCredentials credentials, VssHttpRequestSettings settings)
+            : base(baseUrl, credentials, settings)
+        {
+        }
+
+        public TokenAdminHttpClient(Uri baseUrl, VssCredentials credentials, params DelegatingHandler[] handlers)
+            : base(baseUrl, credentials, handlers)
+        {
+        }
+
+        public TokenAdminHttpClient(Uri baseUrl, VssCredentials credentials, VssHttpRequestSettings settings, params DelegatingHandler[] handlers)
+            : base(baseUrl, credentials, settings, handlers)
+        {
+        }
+
+        public TokenAdminHttpClient(Uri baseUrl, HttpMessageHandler pipeline, bool disposeHandler)
+            : base(baseUrl, pipeline, disposeHandler)
+        {
+        }
+
+        /// <summary>
+        /// [Preview API] Lists of all the session token details of the personal access tokens (PATs) for a particular user.
+        /// </summary>
+        /// <param name="subjectDescriptor">The descriptor of the target user.</param>
+        /// <param name="pageSize">The maximum number of results to return on each page.</param>
+        /// <param name="continuationToken">An opaque data blob that allows the next page of data to resume immediately after where the previous page ended. The only reliable way to know if there is more data left is the presence of a continuation token.</param>
+        /// <param name="userState"></param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        public Task<TokenAdminPagedSessionTokens> ListPersonalAccessTokensAsync(
+            SubjectDescriptor subjectDescriptor,
+            int? pageSize = null,
+            string continuationToken = null,
+            object userState = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            HttpMethod httpMethod = new HttpMethod("GET");
+            Guid locationId = new Guid("af68438b-ed04-4407-9eb6-f1dbae3f922e");
+            object routeValues = new { subjectDescriptor = subjectDescriptor };
+
+            List<KeyValuePair<string, string>> queryParams = new List<KeyValuePair<string, string>>();
+            if (pageSize != null)
+            {
+                queryParams.Add("pageSize", pageSize.Value.ToString(CultureInfo.InvariantCulture));
+            }
+            if (!string.IsNullOrEmpty(continuationToken))
+            {
+                queryParams.Add("continuationToken", continuationToken);
+            }
+
+            return SendAsync<TokenAdminPagedSessionTokens>(
+                httpMethod,
+                locationId,
+                routeValues: routeValues,
+                version: new ApiResourceVersion("5.0-preview.1"),
+                queryParameters: queryParams,
+                userState: userState,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        /// [Preview API] Creates a revocation rule to prevent the further usage of any OAuth authorizations that were created before the current point in time and which match the conditions in the rule.
+        /// </summary>
+        /// <param name="revocationRule">The revocation rule to create. The rule must specify a scope, after which preexisting OAuth authorizations that match that scope will be rejected. For a list of all OAuth scopes supported by VSTS, see: https://docs.microsoft.com/en-us/vsts/integrate/get-started/authentication/oauth?view=vsts#scopes</param>
+        /// <param name="userState"></param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        public async Task CreateRevocationRuleAsync(
+            TokenAdminRevocationRule revocationRule,
+            object userState = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            HttpMethod httpMethod = new HttpMethod("POST");
+            Guid locationId = new Guid("ee4afb16-e7ab-4ed8-9d4b-4ef3e78f97e4");
+            HttpContent content = new ObjectContent<TokenAdminRevocationRule>(revocationRule, new VssJsonMediaTypeFormatter(true));
+
+            using (HttpResponseMessage response = await SendAsync(
+                httpMethod,
+                locationId,
+                version: new ApiResourceVersion("5.0-preview.1"),
+                userState: userState,
+                cancellationToken: cancellationToken,
+                content: content).ConfigureAwait(false))
+            {
+                return;
+            }
+        }
+
+        /// <summary>
+        /// [Preview API] Revokes the listed OAuth authorizations.
+        /// </summary>
+        /// <param name="revocations">The list of objects containing the authorization IDs of the OAuth authorizations, such as session tokens retrieved by listed a users PATs, that should be revoked.</param>
+        /// <param name="userState"></param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        public async Task RevokeAuthorizationsAsync(
+            IEnumerable<TokenAdminRevocation> revocations,
+            object userState = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            HttpMethod httpMethod = new HttpMethod("POST");
+            Guid locationId = new Guid("a9c08b2c-5466-4e22-8626-1ff304ffdf0f");
+            HttpContent content = new ObjectContent<IEnumerable<TokenAdminRevocation>>(revocations, new VssJsonMediaTypeFormatter(true));
+
+            using (HttpResponseMessage response = await SendAsync(
+                httpMethod,
+                locationId,
+                version: new ApiResourceVersion("5.0-preview.1"),
+                userState: userState,
+                cancellationToken: cancellationToken,
+                content: content).ConfigureAwait(false))
+            {
+                return;
+            }
+        }
+    }
+}

--- a/ClientLibrary/Snippets/Microsoft.TeamServices.Samples.Client/TokenAdmin/TokenAdminSample.cs
+++ b/ClientLibrary/Snippets/Microsoft.TeamServices.Samples.Client/TokenAdmin/TokenAdminSample.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.Services.Graph.Client;
+using Microsoft.VisualStudio.Services.TokenAdmin.Client;
+using Microsoft.VisualStudio.Services.WebApi;
+
+namespace Microsoft.TeamServices.Samples.Client.TokenAdmin
+{
+    /// <summary>
+    /// This sample shows how you can use the VSTS REST APIs to find and revoke 
+    /// personal access tokens (PATs) for users in your organization.
+    /// It also shows how to create revocation rules that prevent access through other OAuth credentials,
+    /// such as self-describing session tokens.
+    /// The sample is written using our C# client libraries, 
+    /// but is commented with the HTTP calls that you can make to perform these same operations directly over the wire.
+    /// </summary>
+    /// <remarks>
+    /// - NOTE ON REQUIRED PERMISSIONS: To be able to call of all the endpoints in this sample, 
+    /// you will need to be an administrator of the target organization.
+    /// Non-administrators will receive an authorization error.
+    /// - NOTE ON CONNECTION DETAILS: For this sample, we will be using the connection from our current client context, 
+    /// which includes our base URL and our authentication credentials through the parameters passed in through the runner.
+    /// If you are calling these endpoints directly over the wire,
+    /// your base URL will be => https://{yourOrganization}.vssps.visualstudio.com
+    /// and the recommended approach for authentication is to acquire an ADAL access token and pass it in the header => Authorization: Bearer {yourADALAccessToken}
+    /// For further guidance on how to acquire an ADAL access token, see:
+    /// https://github.com/Microsoft/vsts-auth-samples/tree/master/ManagedClientConsoleAppSample
+    /// For further guidance on other authentication options, see:
+    /// https://docs.microsoft.com/en-us/vsts/integrate/get-started/authentication/authentication-guidance?view=vsts
+    /// </remarks>
+    [ClientSample(TokenAdminResourceIds.AreaName)]
+    public class TokenAdminSample : ClientSample
+    {
+        // The areas of the VSTS REST API / HTTP clients that we will be using for these administration tasks are:
+        // - the Graph endpoints, corresponding to the path pattern: /_apis/graph/*
+        // - the TokenAdmin endpoints, corresponding to the path pattern: /_apis/tokenAdmin/*
+        //   The C# client for this area may not be available until the next release of our client libraries,
+        //   but the REST endpoints themselves should be available at the time of publishing.
+
+        [ClientSampleMethod(TokenAdminResourceIds.AreaName, TokenAdminResourceIds.PersonalAccessTokensResource)]
+        public List<Guid> GetPersonalAccessTokenDetailsForUsersInYourOrganization()
+        {
+            List<Guid> authorizationIds = new List<Guid>();
+            
+            var graphHttpClient = Context.Connection.GetClient<GraphHttpClient>();
+            var tokenAdminHttpClient = Context.Connection.GetClient<TokenAdminHttpClient>();
+
+            // 1. RETRIEVING USERS
+
+            // First, we will use the Graph endpoints to find all of the users in the organization.
+            // This is a paginated API, so you may need to keep track of the continuation token
+            // and send multiple requests depending on the number of users in your organization.
+
+            string userContinuationToken = null;
+
+            do
+            {
+                // Make a call to retrieve the next page of users:
+                // HTTP: GET /_apis/graph/users[?continuationToken={userContinuationToken}]
+                //       => 200 OK {
+                //                   "count":n,
+                //                   "value":[{
+                //                      "descriptor":"{user.Descriptor}",
+                //                        …
+                //                 },…]
+                var pageOfUsers = graphHttpClient.ListUsersAsync(continuationToken: userContinuationToken).SyncResult();
+
+                // The continuation token, if any, is returned in the X-MS-ContinuationToken response header:
+                userContinuationToken = pageOfUsers.ContinuationToken?.SingleOrDefault();
+
+                // 2. RETRIEVING AUTHORIZATION IDS FOR A USER'S PERSONAL ACCESS TOKENS
+
+                // For each user, you can retrieve the authorization IDs corresponding to their personal access tokens as shown below.
+                // This is a paginated API, so you may need to keep track of the continuation token
+                // and send multiple requests depending on the number of PATs associated with the user.
+                // The page size is client-configurable up to a server-side limit.
+                // If you pass too high a value, you will receive an error.
+                var patPageSize = 20;
+
+                foreach (var user in pageOfUsers.GraphUsers)
+                {
+                    Guid? patContinuationToken = null;
+
+                    do
+                    {
+                        // Make a call to retrieve the next page of PATs:
+                        // HTTP: GET /_apis/tokenAdmin/personalAccessTokens/{user.Descriptor}[&continuationToken={patContinuationToken}]
+                        //       => 200 OK {
+                        //                   "count":n,
+                        //                   "value":[{
+                        //                      "authorizationId":"{pat.AuthorizationId}",
+                        //                        …
+                        //                   },…],
+                        //                   "continuationToken":"{patContinuationToken}"
+                        //                 }
+                        var pageOfPats = tokenAdminHttpClient.ListPersonalAccessTokensAsync(
+                            user.Descriptor, pageSize: patPageSize, continuationToken: patContinuationToken?.ToString()).SyncResult();
+
+                        // In this case, the continuation token is returned in the response body as shown above.
+                        patContinuationToken = pageOfPats.ContinuationToken;
+
+                        // Track the authorization IDs from the objects returned in the response:
+                        authorizationIds.AddRange(pageOfPats.SessionTokens.Select(pat => pat.AuthorizationId));
+                    }
+                    // Repeat the above while we still have more pages of PATs:
+                    while (patContinuationToken != null && patContinuationToken != Guid.Empty);
+                }
+            }
+            // Repeat the above while we still have more pages of users:
+            while (!string.IsNullOrEmpty(userContinuationToken));
+
+            return authorizationIds;
+        }
+
+        [ClientSampleMethod(TokenAdminResourceIds.AreaName, TokenAdminResourceIds.RevocationsResource)]
+        public void RevokePersonalAccessTokensForUsersInYourOrganization()
+        {
+            var tokenAdminHttpClient = Context.Connection.GetClient<TokenAdminHttpClient>();
+
+            var authorizationIds = GetPersonalAccessTokenDetailsForUsersInYourOrganization();
+
+            // 3. REVOKING THE AUTHORIZATIONS
+
+            // Once you have the list of authorization IDs you want to revoke, 
+            // you can use the following token administration endpoints to revoke them in batch, up to a server-side limit. 
+            // Just as we've structure it here, you can revoke a list of authorizations that correspond to multiple users in one call,
+            // but keep in mind that you will receive an error if you pass too many revocations at once.
+
+            var revocations = authorizationIds.Select(id => new TokenAdminRevocation { AuthorizationId = id });
+
+            // HTTP: POST /_apis/tokenAdmin/revocations
+            //       [{
+            //          "authorizationId":"{authorizationId}"
+            //        },…]
+            //       => 204 No Content
+            tokenAdminHttpClient.RevokeAuthorizationsAsync(revocations).SyncResult();
+        }
+
+        [ClientSampleMethod(TokenAdminResourceIds.AreaName, TokenAdminResourceIds.RevocationRulesResource)]
+        public void RevokeSelfDescribingSessionTokensForUsersInYourOrganization()
+        {
+            var tokenAdminHttpClient = Context.Connection.GetClient<TokenAdminHttpClient>();
+
+            ////// CREATING OAUTH REVOCATION RULES
+
+            // Not all kinds of OAuth authorizations can be revoked directly.
+            // Some, such as self-describing session tokens, must instead by revoked by creating a rule
+            // which will be evaluated and used to reject matching OAuth credentials at authentication time.
+            // Revocation rules as shown here will apply to all credentials that were issued before the datetime
+            // at which the rule was created, and which match a particular OAuth scope.
+            // For a list of all OAuth scopes supported by VSTS, see: 
+            // https://docs.microsoft.com/en-us/vsts/integrate/get-started/authentication/oauth?view=vsts#scopes
+
+            var scopeToRevoke = "vso.code";
+            var revocationRule = new TokenAdminRevocationRule { Scope = scopeToRevoke };
+
+            // HTTP: POST /_apis/tokenAdmin/revocationRules
+            //       {
+            //         "scope":"{scopeToRevoke}"
+            //       }
+            //       => 204 No Content
+            tokenAdminHttpClient.CreateRevocationRuleAsync(revocationRule).SyncResult();
+        }
+    }
+}


### PR DESCRIPTION
The TokenAdmin sample shows organization administrators how they can use the VSTS REST APIs to find and revoke personal access tokens (PATs) for users in their organization. It also shows how to create revocation rules that prevent access through other OAuth credentials, such as self-describing session tokens. The sample is written using our C# client libraries, but is commented with the HTTP calls that administrators can make to perform these same operations directly over the wire.

The methods in this sample, and the endpoints they cover are:

- GetPersonalAccessTokenDetailsForUsersInYourOrganization
  `GET /_apis/tokenAdmin/personalAccessTokens/{subjectDescriptor}`

- RevokePersonalAccessTokensForUsersInYourOrganization
  `POST /_apis/tokenAdmin/revocations`

- RevokeSelfDescribingSessionTokensForUsersInYourOrganization
  `POST /_apis/tokenAdmin/revocationRules`