### PR TITLE
VSTS organization URL helper samples

### DIFF
--- a/ClientLibrary/Quickstarts/netcore/ShowWorkItemConsole/README.md
+++ b/ClientLibrary/Quickstarts/netcore/ShowWorkItemConsole/README.md
@@ -6,11 +6,15 @@ This sample shows how to use the Work Item Tracking client, but other clients (b
 
 ## How to run
 
-1. If you do not already have a Visual Studio Team Services account, [create one](https://docs.microsoft.com/vsts/organizations/accounts/create-account-msa-or-work-student?view=vsts) (it's free)
+1. If you do not already have a Visual Studio Team Services account, [create one](https://docs.microsoft.com/vsts/organizations/accounts/create-organization-msa-or-work-student?view=vsts) (it's free)
+
 2. Create a work item in your account
+
 3. Create a personal access token ([steps](https://docs.microsoft.com/vsts/organizations/accounts/use-personal-access-tokens-to-authenticate?view=vsts))
+
 4. Install [.NET SDK (2.0 or later)](https://microsoft.com/net/core)
+
 5. Build `dotnet build`
    > Note: you may see warnings about certain dependencies not being fully compatible with the project. This is expected and is due to some dependencies not explicitly listing .NET Standard or .NET Core as a supported framework. 
 
-6. Run `dotnet run https://{account}.visualstudio.com {token} {workItemId}` (substituting these values for your account name, your personal access token, and a valid work item ID)
+6. Run `dotnet run {organizationName} {token} {workItemId}` (substituting these values for your VSTS organization name, your personal access token, and a valid work item ID)

--- a/ClientLibrary/Quickstarts/netcore/ShowWorkItemConsole/ShowWorkItemConsole.csproj
+++ b/ClientLibrary/Quickstarts/netcore/ShowWorkItemConsole/ShowWorkItemConsole.csproj
@@ -9,4 +9,8 @@
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.137.0-preview" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\Helpers\Helpers.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Helpers/Helpers.csproj
+++ b/Helpers/Helpers.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+    <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.137.0-preview" />
+  </ItemGroup>
+
+</Project>

--- a/Helpers/OrganizationUrlHelpers.cs
+++ b/Helpers/OrganizationUrlHelpers.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.Location;
+using Microsoft.VisualStudio.Services.WebApi;
+
+namespace Samples.Helpers
+{
+    /// <summary>
+    /// Helper methods for building URLs to VSTS organization ("account") resources.
+    /// </summmary> 
+    public static class OrganizationUrlHelpers
+    {
+        /// <summary>
+        /// Gets the connection URL for the specified VSTS organization name.
+        /// </summary>
+        public static async Task<Uri> GetConnectionUrl(string organizationName)
+        {
+            try
+            {
+                HttpResponseMessage response = await s_client.GetAsync($"https://app.vssps.visualstudio.com/_apis/resourceAreas?accountName={organizationName}");
+            
+                var wrapper = await response.Content.ReadAsAsync<VssJsonCollectionWrapper<List<ResourceAreaInfo>>>();
+
+                return new Uri(wrapper.Value.First(resourceArea => resourceArea.Id == s_coreResourceAreaId).LocationUrl);
+            }
+            catch (Exception ex)
+            {
+                throw new OrganizationNotFoundException(organizationName, ex);
+            }
+        }
+
+        /// <summary>
+        /// Gets the connection URL for the specified VSTS organization ID.
+        /// </summary>
+        public static async Task<Uri> GetConnectionUrl(Guid organizationId)
+        {
+            try
+            {
+                HttpResponseMessage response = await s_client.GetAsync($"https://app.vssps.visualstudio.com/_apis/resourceAreas?hostId={organizationId}");
+            
+                var wrapper = await response.Content.ReadAsAsync<VssJsonCollectionWrapper<List<ResourceAreaInfo>>>();
+
+                return new Uri(wrapper.Value.First(resourceArea => resourceArea.Id == s_coreResourceAreaId).LocationUrl);
+            }
+            catch (Exception ex)
+            {
+                throw new OrganizationNotFoundException(organizationId.ToString(), ex);
+            }
+        }
+
+        private static readonly HttpClient s_client = new HttpClient();
+
+        public static readonly Guid s_coreResourceAreaId = Guid.Parse("79134C72-4A58-4B42-976C-04E7115F32BF");
+    }
+    
+    public class OrganizationNotFoundException : Exception
+    {
+        public OrganizationNotFoundException(string message, Exception ex)
+            : base(message, ex)
+        {  
+        }
+    }
+
+}

--- a/Helpers/README.md
+++ b/Helpers/README.md
@@ -1,0 +1,37 @@
+# Helpers
+
+This project include various useful "helper" samples.
+
+## OrganizationUrlHelpers 
+
+Provides sample helper methods for properly constructing URLs to VSTS organizations (formerly "account") from an organizastion ID or name.
+
+### Create a connection to an organization using its name
+
+```cs
+public async Task DoSomething()
+{
+    Uri orgUrl = OrganizationUrlHelpers
+        .GetConnectionUrl("myOrgName");  // https://myorgname.visualstudio.com
+
+    VssConnection orgConnection = new VssConnection(orgUrl, credentials);
+
+    BuildHttpClient buildClient = orgConnection.GetClient<BuildHttpClient>();
+}
+```
+
+### Create a connection to an organization using its ID
+
+```cs
+public async Task DoSomething()
+{
+    Guid orgId = Guid.Parse("279ed1c4-2f72-4e61-8c95-4bafcc13fd02"); // ID for the "MyOrgName" organzation 
+
+    Uri orgUrl = OrganizationUrlHelpers
+        .GetConnectionUrl(orgId);  // https://myorgname.visualstudio.com
+
+    VssConnection orgConnection = new VssConnection(orgUrl, credentials);
+
+    BuildHttpClient buildClient = orgConnection.GetClient<BuildHttpClient>();
+}
+```


### PR DESCRIPTION
Samples showing how to properly construct a URL to a VSTS organization (formerly called "account") using either its name (e.g. "Fabrikam") or its GUID identifier.

Example of how to use the new helper:

```cs
public async Task DoSomething()
{
    Uri orgUrl = OrganizationUrlHelpers
        .GetConnectionUrl("myOrgName");  // typically resolves to https://myorgname.visualstudio.com

    VssConnection orgConnection = new VssConnection(orgUrl, credentials);

    BuildHttpClient buildClient = orgConnection.GetClient<BuildHttpClient>();
}
```