### PR TITLE
Renamed VSTS To Azure DevOps Services and Azure DevOps Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Take a minute to explore the repo. It contains short snippets as well as longer 
 
 For .NET developers, the primary (and highly recommended) way to integrate with Team Services and Team Foundation Server is via our public .NET client libraries available on Nuget. [Microsoft.TeamFoundationServer.Client](https://www.nuget.org/packages/Microsoft.TeamFoundationServer.Client) is the most popular Nuget package and contains clients for interacting with work item tracking, Git, version control, build, release management and other services.
 
-See the [Team Services client library documentation](https://www.visualstudio.com/docs/integrate/get-started/client-libraries/dotnet) for more details.
+See the [Azure DevOps Services client library documentation](https://www.visualstudio.com/docs/integrate/get-started/client-libraries/dotnet) for more details.
 
 ### Sample console program
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# .NET samples for Visual Studio Team Services
+# .NET samples for Azure DevOps Services
 
 [![buildstatus](https://mseng.visualstudio.com/_apis/public/build/definitions/b924d696-3eae-4116-8443-9a18392d8544/5045/badge)](https://mseng.visualstudio.com/VSOnline/Open%20ALM/_build/index?context=mine&path=%5C&definitionId=5045&_a=completed)
 
-This repository contains C# samples that show how to integrate with Team Services and Team Foundation Server using our [public client libraries](https://www.nuget.org/profiles/nugetvss), service hooks, and more.
+This repository contains C# samples that show how to integrate with Azure DevOps Services and Azure DevOps Server using our [public client libraries](https://www.nuget.org/profiles/nugetvss), service hooks, and more.
 
 ## Explore the samples
 
-Take a minute to explore the repo. It contains short snippets as well as longer examples that demonstrate how to integrate with Team Services and Team Foundation
+Take a minute to explore the repo. It contains short snippets as well as longer examples that demonstrate how to integrate with Azure DevOps Services and Azure DevOps Server:
 
 * **Snippets**: short reusable code blocks demonstrating how to call specific APIs.
 * **Quickstarts**: self-contained programs demonstrating a specific scenario, typically by calling multiple APIs.


### PR DESCRIPTION
Updated Readme.md to modify references to VSTS And TFS to Azure DevOps Services and Azure DevOps Server. 
